### PR TITLE
Replace non-wikipedia property in metadata

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -81,7 +81,7 @@
 		<meta property="role" refines="#author" scheme="marc:relators">aut</meta>
 		<dc:contributor id="artist">John Constable</dc:contributor>
 		<meta property="file-as" refines="#artist">Constable, John</meta>
-		<meta property="se:url.encyclopedia.wikipedia" refines="#artist">https://www.wikiart.org/en/john-constable/willy-lot-s-house-1810</meta>
+		<meta property="se:url.encyclopedia.wikipedia" refines="#artist">https://en.wikipedia.org/wiki/John_Constable</meta>
 		<meta property="se:url.authority.nacoaf" refines="#artist">https://id.loc.gov/authorities/names/n80007977</meta>
 		<meta property="role" refines="#artist" scheme="marc:relators">art</meta>
 		<dc:contributor id="transcriber-1">Eve Sobol</dc:contributor>


### PR DESCRIPTION
WikiArt is not a Wikimedia project.